### PR TITLE
Update diffskyopt according to Diffstar `v1.0`

### DIFF
--- a/diffskyopt/diffsky_model.py
+++ b/diffskyopt/diffsky_model.py
@@ -125,7 +125,7 @@ def generate_lc_data_kern(
     t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
     precomputed_ssp_mag_table = psspp.get_precompute_ssp_mag_redshift_table(
-        tcurves, ssp_data, z_phot_table
+        tcurves, ssp_data, z_phot_table, cosmo_params
     )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)
 
@@ -349,6 +349,7 @@ def generate_weighted_sobol_lc_data(
     comm=None,
     drn_filters=FILTERS_DIR,
     drn_dsps=DATA_DIR,
+    cosmo_params=DEFAULT_COSMOLOGY,
 ):
     if comm is None:
         comm = MPI.COMM_WORLD
@@ -423,7 +424,7 @@ def generate_weighted_sobol_lc_data(
     t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
     precomputed_ssp_mag_table = psspp.get_precompute_ssp_mag_redshift_table(
-        tcurves, ssp_data, z_phot_table
+        tcurves, ssp_data, z_phot_table, cosmo_params
     )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)
 

--- a/diffskyopt/diffsky_model.py
+++ b/diffskyopt/diffsky_model.py
@@ -9,6 +9,7 @@ from diffmah.diffmah_kernels import _log_mah_kern
 from diffmah.diffmahpop_kernels.bimod_censat_params import DEFAULT_DIFFMAHPOP_PARAMS
 from diffmah.diffmahpop_kernels.mc_bimod_cens import mc_cenpop
 from diffsky.experimental import lc_phot_kern
+from diffsky.experimental import precompute_ssp_phot as psspp
 from diffsky.experimental.lc_phot_kern import mclh
 from diffsky.experimental.mc_lightcone_halos import get_nhalo_weighted_lc_grid
 from diffsky.mass_functions import mc_hosts
@@ -123,7 +124,7 @@ def generate_lc_data_kern(
     t0 = lc_phot_kern.flat_wcdm.age_at_z0(*cosmo_params)
     t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
-    precomputed_ssp_mag_table = mclh.get_precompute_ssp_mag_redshift_table(
+    precomputed_ssp_mag_table = psspp.get_precompute_ssp_mag_redshift_table(
         tcurves, ssp_data, z_phot_table
     )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)
@@ -421,7 +422,7 @@ def generate_weighted_sobol_lc_data(
     t0 = lc_phot_kern.flat_wcdm.age_at_z0(*DEFAULT_COSMOLOGY)
     t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
-    precomputed_ssp_mag_table = mclh.get_precompute_ssp_mag_redshift_table(
+    precomputed_ssp_mag_table = psspp.get_precompute_ssp_mag_redshift_table(
         tcurves, ssp_data, z_phot_table
     )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)

--- a/diffskyopt/diffsky_model.py
+++ b/diffskyopt/diffsky_model.py
@@ -6,15 +6,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from diffmah.diffmah_kernels import _log_mah_kern
-from diffmah.diffmahpop_kernels.bimod_censat_params import \
-    DEFAULT_DIFFMAHPOP_PARAMS
+from diffmah.diffmahpop_kernels.bimod_censat_params import DEFAULT_DIFFMAHPOP_PARAMS
 from diffmah.diffmahpop_kernels.mc_bimod_cens import mc_cenpop
 from diffsky.experimental import lc_phot_kern
 from diffsky.experimental.lc_phot_kern import mclh
 from diffsky.experimental.mc_lightcone_halos import get_nhalo_weighted_lc_grid
 from diffsky.mass_functions import mc_hosts
-from diffsky.mass_functions.fitting_utils.calibrations import \
-    hacc_core_shmf_params
+from diffsky.mass_functions.fitting_utils.calibrations import hacc_core_shmf_params
 from diffsky.mass_functions.hmf_calibrations import smdpl_hmf, smdpl_hmf_subs
 from dsps import load_ssp_templates
 from dsps.cosmology import flat_wcdm
@@ -24,10 +22,10 @@ from dsps.data_loaders.defaults import TransmissionCurve
 from mpi4py import MPI
 from scipy.stats import qmc
 
-DATA_DIR = os.environ.get("DIFFSKYOPT_COSMOS_DIR",
-                          "/lcrc/project/halotools/COSMOS/")
-FILTERS_DIR = os.environ.get("DIFFSKYOPT_FILTERS_DIR",
-                             "/home/apearl/data/cosmos_filters/")
+DATA_DIR = os.environ.get("DIFFSKYOPT_COSMOS_DIR", "/lcrc/project/halotools/COSMOS/")
+FILTERS_DIR = os.environ.get(
+    "DIFFSKYOPT_FILTERS_DIR", "/lcrc/project/halotools/COSMOS/cosmos_filters"
+)
 DATA_DIR = pathlib.Path(DATA_DIR)
 FILTERS_DIR = pathlib.Path(FILTERS_DIR)
 
@@ -78,20 +76,20 @@ assert len(FILTER_FILES) == len(FILTER_NAMES)
 
 
 def cosmos_mags_to_colors(mags, filter_names=FILTER_NAMES):
-    assert mags.shape[1] == len(filter_names), \
-        f"mags must be shape (N, {len(filter_names)})"
-    filter_set_names = list(dict.fromkeys(
-        [x.split("_")[0] for x in filter_names]))
+    assert mags.shape[1] == len(
+        filter_names
+    ), f"mags must be shape (N, {len(filter_names)})"
+    filter_set_names = list(dict.fromkeys([x.split("_")[0] for x in filter_names]))
     filter_set_inds = [
         [i for i, fname in enumerate(filter_names) if fname.startswith(sname)]
         for sname in filter_set_names
     ]
     combined_mag_sets = [
-        jnp.stack([mags[:, i] for i in inds], axis=1)
-        for inds in filter_set_inds
+        jnp.stack([mags[:, i] for i in inds], axis=1) for inds in filter_set_inds
     ]
-    return jnp.concatenate([
-        -jnp.diff(mag_set, axis=1) for mag_set in combined_mag_sets], axis=1)
+    return jnp.concatenate(
+        [-jnp.diff(mag_set, axis=1) for mag_set in combined_mag_sets], axis=1
+    )
 
 
 def generate_lc_data_kern(
@@ -119,16 +117,15 @@ def generate_lc_data_kern(
         assert hmf_calibration is None, f"Unrecognized {hmf_calibration=}"
 
     lc_halopop = mclh.mc_lightcone_host_halo_diffmah(
-        *mclh_args, logmp_cutoff=logmp_cutoff, **mclh_kwargs)  # type: ignore
+        *mclh_args, logmp_cutoff=logmp_cutoff, **mclh_kwargs
+    )  # type: ignore
 
     t0 = lc_phot_kern.flat_wcdm.age_at_z0(*cosmo_params)
-    t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN,
-                           t0, lc_phot_kern.N_SFH_TABLE)
+    t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
-    precomputed_ssp_mag_table = \
-        mclh.get_precompute_ssp_mag_redshift_table(
-            tcurves, ssp_data, z_phot_table
-        )
+    precomputed_ssp_mag_table = mclh.get_precompute_ssp_mag_redshift_table(
+        tcurves, ssp_data, z_phot_table
+    )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)
 
     lc_data = lc_phot_kern.LCData(
@@ -145,18 +142,32 @@ def generate_lc_data_kern(
     return lc_data
 
 
-def generate_lc_data(z_min, z_max, lgmp_min, sky_area_degsq,
-                     ran_key=None, n_z_phot_table=15, logmp_cutoff=0.0,
-                     hmf_calibration=None, drn_filters=FILTERS_DIR,
-                     drn_dsps=DATA_DIR):
+def generate_lc_data(
+    z_min,
+    z_max,
+    lgmp_min,
+    sky_area_degsq,
+    ran_key=None,
+    n_z_phot_table=15,
+    logmp_cutoff=0.0,
+    hmf_calibration=None,
+    drn_filters=FILTERS_DIR,
+    drn_dsps=DATA_DIR,
+):
     if ran_key is None:
         ran_key = jax.random.key(0)
 
     ssp_data = load_ssp_templates(drn_dsps / SSP_FILE)
 
     ffiles = [drn_filters / fn for fn in FILTER_FILES]
-    tcurves = [load_transmission_curve(fn) if str(fn).endswith(".h5") else
-               TransmissionCurve(*np.loadtxt(fn).T) for fn in ffiles]
+    tcurves = [
+        (
+            load_transmission_curve(fn)
+            if str(fn).endswith(".h5")
+            else TransmissionCurve(*np.loadtxt(fn).T)
+        )
+        for fn in ffiles
+    ]
 
     z_phot_table = np.linspace(z_min, z_max, n_z_phot_table)
 
@@ -178,22 +189,27 @@ def generate_lc_data(z_min, z_max, lgmp_min, sky_area_degsq,
 
 def lc_data_slice(lc_data, selection):
     downsampled_mah_params = lc_data.mah_params._make(
-        [x[selection] for x in lc_data.mah_params])
-    return lc_data._make([
-        lc_data.z_obs[selection],
-        lc_data.t_obs[selection],
-        downsampled_mah_params,
-        lc_data.logmp0[selection],
-        *lc_data[4:]
-    ])
+        [x[selection] for x in lc_data.mah_params]
+    )
+    return lc_data._make(
+        [
+            lc_data.z_obs[selection],
+            lc_data.t_obs[selection],
+            downsampled_mah_params,
+            lc_data.logmp0[selection],
+            *lc_data[4:],
+        ]
+    )
 
 
-def downsample_upweight_lc_data(lc_data, lgmp_min, n_halo_weight_bins=10,
-                                max_n_halos_per_bin=100, ran_key=None):
+def downsample_upweight_lc_data(
+    lc_data, lgmp_min, n_halo_weight_bins=10, max_n_halos_per_bin=100, ran_key=None
+):
     if ran_key is None:
         ran_key = jax.random.key(1)
     logmp0_bin_edges = jnp.linspace(
-        lgmp_min-0.01, lc_data.logmp0.max()+0.01, n_halo_weight_bins)
+        lgmp_min - 0.01, lc_data.logmp0.max() + 0.01, n_halo_weight_bins
+    )
     hist, _ = jnp.histogram(lc_data.logmp0, bins=logmp0_bin_edges)
     bin_ind = jnp.digitize(lc_data.logmp0, logmp0_bin_edges) - 1
 
@@ -207,10 +223,16 @@ def downsample_upweight_lc_data(lc_data, lgmp_min, n_halo_weight_bins=10,
             # Randomly sample max_n_halos_per_bin halos from this bin
             bin_halo_indices = jnp.where(bin_ind == bin_i)[0]
             bin_halo_weights = jnp.full(
-                (max_n_halos_per_bin,), hist[bin_i] / max_n_halos_per_bin)
+                (max_n_halos_per_bin,), hist[bin_i] / max_n_halos_per_bin
+            )
             downsampled_halo_indices.append(
-                jax.random.choice(ran_key, bin_halo_indices,
-                                  shape=(max_n_halos_per_bin,), replace=False))
+                jax.random.choice(
+                    ran_key,
+                    bin_halo_indices,
+                    shape=(max_n_halos_per_bin,),
+                    replace=False,
+                )
+            )
             downsampled_halo_weights.append(bin_halo_weights)
     downsampled_halo_indices = jnp.concatenate(downsampled_halo_indices)
     downsampled_halo_weights = jnp.concatenate(downsampled_halo_weights)
@@ -219,20 +241,30 @@ def downsample_upweight_lc_data(lc_data, lgmp_min, n_halo_weight_bins=10,
     return downsampled_lc_data, downsampled_halo_weights
 
 
-def get_nhalo_from_grid_interp(tot_num_halos, z_obs, logmp_obs_mf,
-                               z_min, z_max, lgmp_min, lgmp_max,
-                               sky_area_degsq, hmf_params, cosmo_params):
+def get_nhalo_from_grid_interp(
+    tot_num_halos,
+    z_obs,
+    logmp_obs_mf,
+    z_min,
+    z_max,
+    lgmp_min,
+    lgmp_max,
+    sky_area_degsq,
+    hmf_params,
+    cosmo_params,
+):
     ngrid_z = 200
     ngrid_m = 200
     ngrid_tot = ngrid_z * ngrid_m
     z_grid = jnp.linspace(z_min, z_max, ngrid_z)
     lgmp_grid = jnp.linspace(lgmp_min, lgmp_max, ngrid_m)
     nhalo_grid = get_nhalo_weighted_lc_grid(
-        lgmp_grid, z_grid, sky_area_degsq, hmf_params, cosmo_params)
+        lgmp_grid, z_grid, sky_area_degsq, hmf_params, cosmo_params
+    )
 
     interpolator = jax.scipy.interpolate.RegularGridInterpolator(
-        (z_grid, lgmp_grid), nhalo_grid,
-        bounds_error=False, fill_value=None)  # type: ignore
+        (z_grid, lgmp_grid), nhalo_grid, bounds_error=False, fill_value=None
+    )  # type: ignore
 
     interp = interpolator(jnp.column_stack([z_obs, logmp_obs_mf]))
     return interp * ngrid_tot / tot_num_halos
@@ -258,9 +290,16 @@ def get_weighted_lightcone_sobol_host_halo_diffmah(
     """
 
     nhalo_weights = get_nhalo_from_grid_interp(
-        tot_num_halos, z_obs, logmp_obs_mf,
-        z_min, z_max, lgmp_min, lgmp_max,
-        sky_area_degsq, hmf_params=hmf_params, cosmo_params=cosmo_params,
+        tot_num_halos,
+        z_obs,
+        logmp_obs_mf,
+        z_min,
+        z_max,
+        lgmp_min,
+        lgmp_max,
+        sky_area_degsq,
+        hmf_params=hmf_params,
+        cosmo_params=cosmo_params,
     )
     # nhalo_weights = nhalo_weighted_lc_grid.flatten()
     # z_obs = np.repeat(z_grid, lgmp_grid.size)
@@ -273,8 +312,7 @@ def get_weighted_lightcone_sobol_host_halo_diffmah(
     logmp_obs_mf_clipped = np.clip(logmp_obs_mf, logmp_cutoff, np.inf)
 
     tarr = np.array((10**lgt0,))
-    args = (diffmahpop_params, tarr, logmp_obs_mf_clipped,
-            t_obs, ran_key, lgt0)
+    args = (diffmahpop_params, tarr, logmp_obs_mf_clipped, t_obs, ran_key, lgt0)
     mah_params_uncorrected = mc_cenpop(*args)[0]  # mah_params, dmhdt, log_mah
 
     logmp_obs_orig = _log_mah_kern(mah_params_uncorrected, t_obs, lgt0)
@@ -296,13 +334,21 @@ def get_weighted_lightcone_sobol_host_halo_diffmah(
     return cenpop_out
 
 
-def generate_weighted_sobol_lc_data(num_halos, z_min, z_max,
-                                    lgmp_min, lgmp_max,
-                                    sky_area_degsq, ran_key=None,
-                                    n_z_phot_table=15, logmp_cutoff=0.0,
-                                    hmf_calibration=None, comm=None,
-                                    drn_filters=FILTERS_DIR,
-                                    drn_dsps=DATA_DIR):
+def generate_weighted_sobol_lc_data(
+    num_halos,
+    z_min,
+    z_max,
+    lgmp_min,
+    lgmp_max,
+    sky_area_degsq,
+    ran_key=None,
+    n_z_phot_table=15,
+    logmp_cutoff=0.0,
+    hmf_calibration=None,
+    comm=None,
+    drn_filters=FILTERS_DIR,
+    drn_dsps=DATA_DIR,
+):
     if comm is None:
         comm = MPI.COMM_WORLD
     if ran_key is None:
@@ -310,10 +356,12 @@ def generate_weighted_sobol_lc_data(num_halos, z_min, z_max,
     ran_key, ran_key_sobol = jax.random.split(ran_key, 2)
 
     # ONLY generate the halos necessary on this rank
-    num_halos_on_rank = num_halos // comm.size + \
-        (1 if comm.rank < num_halos % comm.size else 0)
-    starting_index = comm.rank * \
-        (num_halos // comm.size) + min(comm.rank, num_halos % comm.size)
+    num_halos_on_rank = num_halos // comm.size + (
+        1 if comm.rank < num_halos % comm.size else 0
+    )
+    starting_index = comm.rank * (num_halos // comm.size) + min(
+        comm.rank, num_halos % comm.size
+    )
 
     # Generate Sobol sequence for halo masses and redshifts
     seed = int(jax.random.randint(ran_key_sobol, (), 0, 2**31 - 1))
@@ -327,22 +375,35 @@ def generate_weighted_sobol_lc_data(num_halos, z_min, z_max,
 
     with warnings.catch_warnings():
         # Ignore warning about Sobol sequences not being fully balanced
-        warnings.filterwarnings(
-            "ignore", category=UserWarning)
+        warnings.filterwarnings("ignore", category=UserWarning)
         sample = sampler.random(num_halos_on_rank)
-    z_obs, logmp_obs_mf = qmc.scale(
-        sample, (z_min, lgmp_min), (z_max, lgmp_max)).T
+    z_obs, logmp_obs_mf = qmc.scale(sample, (z_min, lgmp_min), (z_max, lgmp_max)).T
 
     ssp_data = load_ssp_templates(os.path.join(drn_dsps, SSP_FILE))
 
     ffiles = [os.path.join(drn_filters, fn) for fn in FILTER_FILES]
-    tcurves = [load_transmission_curve(fn) if str(fn).endswith(".h5") else
-               TransmissionCurve(*np.loadtxt(fn).T) for fn in ffiles]
+    tcurves = [
+        (
+            load_transmission_curve(fn)
+            if str(fn).endswith(".h5")
+            else TransmissionCurve(*np.loadtxt(fn).T)
+        )
+        for fn in ffiles
+    ]
 
     z_phot_table = np.linspace(z_min, z_max, n_z_phot_table)
 
-    mclh_args = (ran_key, num_halos, z_obs, logmp_obs_mf, z_min, z_max,
-                 lgmp_min, lgmp_max, sky_area_degsq)
+    mclh_args = (
+        ran_key,
+        num_halos,
+        z_obs,
+        logmp_obs_mf,
+        z_min,
+        z_max,
+        lgmp_min,
+        lgmp_max,
+        sky_area_degsq,
+    )
     mclh_kwargs = dict()
     if hmf_calibration == "smdpl_hmf":
         mclh_kwargs["hmf_params"] = smdpl_hmf.HMF_PARAMS
@@ -354,16 +415,15 @@ def generate_weighted_sobol_lc_data(num_halos, z_min, z_max,
         assert hmf_calibration is None, f"Unrecognized {hmf_calibration=}"
 
     res = get_weighted_lightcone_sobol_host_halo_diffmah(
-        *mclh_args, logmp_cutoff=logmp_cutoff, **mclh_kwargs)  # type: ignore
+        *mclh_args, logmp_cutoff=logmp_cutoff, **mclh_kwargs
+    )  # type: ignore
 
     t0 = lc_phot_kern.flat_wcdm.age_at_z0(*DEFAULT_COSMOLOGY)
-    t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN,
-                           t0, lc_phot_kern.N_SFH_TABLE)
+    t_table = jnp.linspace(lc_phot_kern.T_TABLE_MIN, t0, lc_phot_kern.N_SFH_TABLE)
 
-    precomputed_ssp_mag_table = \
-        mclh.get_precompute_ssp_mag_redshift_table(
-            tcurves, ssp_data, z_phot_table
-        )
+    precomputed_ssp_mag_table = mclh.get_precompute_ssp_mag_redshift_table(
+        tcurves, ssp_data, z_phot_table
+    )
     wave_eff_table = lc_phot_kern.get_wave_eff_table(z_phot_table, tcurves)
 
     lc_data = lc_phot_kern.LCData(
@@ -383,8 +443,13 @@ def generate_weighted_sobol_lc_data(num_halos, z_min, z_max,
 
 @jax.jit
 def compute_targets_and_weights(
-        u_param_arr, lc_data, i_band_thresh=23.0,
-        thresh_softening=0.1, weights=None, ran_key=None):
+    u_param_arr,
+    lc_data,
+    i_band_thresh=23.0,
+    thresh_softening=0.1,
+    weights=None,
+    ran_key=None,
+):
     # For mag bands = g, r, i, z -> i_band_ind = 2
 
     if ran_key is None:
@@ -393,21 +458,23 @@ def compute_targets_and_weights(
         weights = 1
 
     lc_phot = lc_phot_kern.multiband_lc_phot_kern_u_param_arr(
-        u_param_arr, ran_key, lc_data)
+        u_param_arr, ran_key, lc_data
+    )
     m_msb, m_mss, m_q, w_msb, w_mss, w_q = lc_phot
 
     # Multiple weights by halo upweights AND i-band threshold weights
     w_msb *= weights * jax.nn.sigmoid(
-        (i_band_thresh - m_msb[:, I_BAND_IND]) / thresh_softening)
+        (i_band_thresh - m_msb[:, I_BAND_IND]) / thresh_softening
+    )
     w_mss *= weights * jax.nn.sigmoid(
-        (i_band_thresh - m_mss[:, I_BAND_IND]) / thresh_softening)
+        (i_band_thresh - m_mss[:, I_BAND_IND]) / thresh_softening
+    )
     w_q *= weights * jax.nn.sigmoid(
-        (i_band_thresh - m_q[:, I_BAND_IND]) / thresh_softening)
+        (i_band_thresh - m_q[:, I_BAND_IND]) / thresh_softening
+    )
 
-    combined_mags = jnp.concatenate(
-        (m_msb, m_mss, m_q), axis=0)
-    combined_weights = jnp.concatenate(
-        (w_msb, w_mss, w_q), axis=0)
+    combined_mags = jnp.concatenate((m_msb, m_mss, m_q), axis=0)
+    combined_weights = jnp.concatenate((w_msb, w_mss, w_q), axis=0)
     z_obs = jnp.tile(lc_data.z_obs[:, None], (3, 1))
 
     # Compute colors without cross-filtering between HSC and UVISTA
@@ -415,7 +482,7 @@ def compute_targets_and_weights(
 
     # Target is the i-band mag + colors between all bands + redshift
     combined_targets = jnp.concatenate(
-        [combined_mags[:, I_BAND_IND, None], z_obs,
-         combined_colors], axis=1)
+        [combined_mags[:, I_BAND_IND, None], z_obs, combined_colors], axis=1
+    )
 
     return combined_targets, combined_weights

--- a/diffskyopt/scripts/cosmos_validation.py
+++ b/diffskyopt/scripts/cosmos_validation.py
@@ -9,6 +9,7 @@ if not MPI.COMM_WORLD.rank:
 import jax
 import numpy as np
 from astropy import units
+
 # import jax.numpy as jnp
 from astropy.cosmology import Planck15
 from diffsky.experimental.diagnostics import check_smhm
@@ -26,27 +27,36 @@ def cosmos_volume(z_min, z_max):
     full_sky_area = (4 * np.pi) * (180 / np.pi) ** 2  # square degrees
     fsky = COSMOS_SKY_AREA / full_sky_area
     vol_com_sphere = Planck15.comoving_volume(  # type: ignore
-        z_max) - Planck15.comoving_volume(z_min)  # type: ignore
-    return fsky*vol_com_sphere / (units.Mpc / Planck15.h)**3  # type: ignore
+        z_max
+    ) - Planck15.comoving_volume(
+        z_min
+    )  # type: ignore
+    return fsky * vol_com_sphere / (units.Mpc / Planck15.h) ** 3  # type: ignore
 
 
-def n_of_z_plot(cosmos_fit, save=False, zbins=30,
-                ax=None, show=True, make_legend=True,
-                model_params=None, prefix="",
-                data_label="COSMOS"):
+def n_of_z_plot(
+    cosmos_fit,
+    save=False,
+    zbins=30,
+    ax=None,
+    show=True,
+    make_legend=True,
+    model_params=None,
+    prefix="",
+    data_label="COSMOS",
+):
     if model_params is None:
         model_params = cosmos_fit.default_u_param_arr
     # i_threshes = [22.0, 23.0, 24.0, 25.0]
     i_threshes = [20.0, 21.5, 23.0, 25.0]
     # Plot a color-magnitude diagram: g-r vs i-band
-    data_targets, data_weights = (cosmos_fit.data_targets,
-                                  cosmos_fit.data_weights)
+    data_targets, data_weights = (cosmos_fit.data_targets, cosmos_fit.data_weights)
 
     # Compute model targets + weights with default u_params
     # and overplot with a seaborn.kdeplot
-    model_targets, model_weights = \
-        cosmos_fit.targets_and_weights_from_params(
-            model_params, ran_key)
+    model_targets, model_weights = cosmos_fit.targets_and_weights_from_params(
+        model_params, ran_key
+    )
     model_targets = np.concatenate(MPI.COMM_WORLD.allgather(model_targets))
     model_weights = np.concatenate(MPI.COMM_WORLD.allgather(model_weights))
     if not MPI.COMM_WORLD.rank:
@@ -59,11 +69,15 @@ def n_of_z_plot(cosmos_fit, save=False, zbins=30,
         dz = np.diff(z_edges)
         for i, ithresh in enumerate(i_threshes):
             data_n_of_z = np.histogram(
-                data_z[data_i < ithresh], z_edges,
-                weights=data_weights[data_i < ithresh])[0]
+                data_z[data_i < ithresh],
+                z_edges,
+                weights=data_weights[data_i < ithresh],
+            )[0]
             model_n_of_z = np.histogram(
-                model_z[model_i < ithresh], z_edges,
-                weights=model_weights[model_i < ithresh])[0]
+                model_z[model_i < ithresh],
+                z_edges,
+                weights=model_weights[model_i < ithresh],
+            )[0]
 
             # cosmos_volume_per_zbin = np.array([
             #     cosmos_volume(*z_edges[i:i+2]) for i in range(len(z_cens))])
@@ -76,8 +90,7 @@ def n_of_z_plot(cosmos_fit, save=False, zbins=30,
 
             if ax is None:
                 ax = plt.subplots()[1]
-            ax.step(z_edges, [data_n_of_z[0], *data_n_of_z],
-                    color=f"C{i}", ls="--")
+            ax.step(z_edges, [data_n_of_z[0], *data_n_of_z], color=f"C{i}", ls="--")
             ax.plot(z_cens, model_n_of_z, label=f"$\\rm m_i < {ithresh:.1f}$")
         ax.step([], [], color="k", ls="--", label=data_label)
         ax.semilogy()
@@ -95,18 +108,26 @@ def n_of_z_plot(cosmos_fit, save=False, zbins=30,
             plt.clf()
 
 
-def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
-                      ax=None, show=True, make_legend=True,
-                      model_params=None, prefix="",
-                      data_label="COSMOS", model_label="Diffsky Model"):
+def n_of_ithresh_plot(
+    cosmos_fit,
+    save=False,
+    ibins=30,
+    ithresh=25.0,
+    ax=None,
+    show=True,
+    make_legend=True,
+    model_params=None,
+    prefix="",
+    data_label="COSMOS",
+    model_label="Diffsky Model",
+):
     if model_params is None:
         model_params = cosmos_fit.default_u_param_arr
-    data_targets, data_weights = (cosmos_fit.data_targets,
-                                  cosmos_fit.data_weights)
+    data_targets, data_weights = (cosmos_fit.data_targets, cosmos_fit.data_weights)
 
-    model_targets, model_weights = \
-        cosmos_fit.targets_and_weights_from_params(
-            model_params, ran_key)
+    model_targets, model_weights = cosmos_fit.targets_and_weights_from_params(
+        model_params, ran_key
+    )
     model_targets = np.concatenate(MPI.COMM_WORLD.allgather(model_targets))
     model_weights = np.concatenate(MPI.COMM_WORLD.allgather(model_weights))
     if not MPI.COMM_WORLD.rank:
@@ -114,12 +135,10 @@ def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
         model_i = model_targets[:, 0]
         all_i = np.concatenate([data_i, model_i])
         i_vals = np.linspace(all_i.min(), ithresh, ibins)
-        data_hist = np.cumsum(
-            np.histogram(data_i, i_vals, weights=data_weights)[0])
-        model_hist = np.cumsum(
-            np.histogram(model_i, i_vals, weights=model_weights)[0])
+        data_hist = np.cumsum(np.histogram(data_i, i_vals, weights=data_weights)[0])
+        model_hist = np.cumsum(np.histogram(model_i, i_vals, weights=model_weights)[0])
 
-        ess = np.sum(data_weights)**2 / np.sum(data_weights**2)
+        ess = np.sum(data_weights) ** 2 / np.sum(data_weights**2)
         f_ess = ess / np.sum(data_weights)
         data_n_of_ithresh = data_hist / COSMOS_SKY_AREA
         model_n_of_ithresh = model_hist / COSMOS_SKY_AREA
@@ -127,8 +146,7 @@ def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
         data_err = data_n_of_ithresh * frac_err
 
         # Fractional residuals
-        frac_resid = (model_n_of_ithresh - data_n_of_ithresh
-                      ) / data_n_of_ithresh
+        frac_resid = (model_n_of_ithresh - data_n_of_ithresh) / data_n_of_ithresh
 
         if ax is None:
             fig = plt.figure(figsize=(6, 6))
@@ -142,8 +160,13 @@ def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
 
         # Upper panel: cumulative counts
         ax.plot(i_vals[1:], data_n_of_ithresh, label=data_label, color="C0")
-        ax.fill_between(i_vals[1:], data_n_of_ithresh + data_err,
-                        data_n_of_ithresh - data_err, color="C0", alpha=0.5)
+        ax.fill_between(
+            i_vals[1:],
+            data_n_of_ithresh + data_err,
+            data_n_of_ithresh - data_err,
+            color="C0",
+            alpha=0.5,
+        )
         ax.plot(i_vals[1:], model_n_of_ithresh, label=model_label, color="C1")
         ax.semilogy()
         ax.set_ylabel("$\\rm n(<mag) \\; [deg^{-2}]$")
@@ -154,8 +177,9 @@ def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
         # Lower panel: fractional residuals
         if ax_resid is not None:
             ax_resid.axhline(0, color="C0")
-            ax_resid.fill_between(i_vals[1:], -frac_err, frac_err,
-                                  color="C0", alpha=0.5)
+            ax_resid.fill_between(
+                i_vals[1:], -frac_err, frac_err, color="C0", alpha=0.5
+            )
             ax_resid.plot(i_vals[1:], frac_resid, color="C1")
             ax_resid.set_ylabel("$\\rm \\Delta n / n$")
             ax_resid.set_xlabel("$\\rm m_i$")
@@ -182,10 +206,10 @@ def n_of_ithresh_plot(cosmos_fit, save=False, ibins=30, ithresh=25.0,
 def smhm_drift_plot(save=False, prefix="", model_params=None):
     if model_params is None:
         model_params = cosmos_fit.default_u_param_arr
-    u_param_collection = dpw.get_u_param_collection_from_u_param_array(
-        model_params)
+    u_param_collection = dpw.get_u_param_collection_from_u_param_array(model_params)
     diffstarpop_params = dpw.get_param_collection_from_u_param_collection(
-        *u_param_collection)[0]
+        *u_param_collection
+    )[0]
 
     if save:
         check_smhm.plot_diffstarpop_insitu_smhm(
@@ -195,28 +219,48 @@ def smhm_drift_plot(save=False, prefix="", model_params=None):
 
 
 parser = argparse.ArgumentParser(
-    description="Validate model vs COSMOS data with n(z) and n(<m_i)")
+    description="Validate model vs COSMOS data with n(z) and n(<m_i)"
+)
 parser.add_argument(
-    "-s", "--save", action="store_true",
-    help="Save plots instead of opening interactive window")
+    "-s",
+    "--save",
+    action="store_true",
+    help="Save plots instead of opening interactive window",
+)
 parser.add_argument(
-    "--prefix", type=str, default="",
-    help="Prefix for saved plot filenames, ignored if --save is not set")
+    "--prefix",
+    type=str,
+    default="",
+    help="Prefix for saved plot filenames, ignored if --save is not set",
+)
 parser.add_argument(
-    "--iband-max", type=float, default=25.0,
-    help="Only fit to data with apparent mag_i < IBAND_MAX")
+    "--iband-max",
+    type=float,
+    default=25.0,
+    help="Only fit to data with apparent mag_i < IBAND_MAX",
+)
 parser.add_argument(
-    "-m", "--lgmp-min", type=float, default=10.5,
-    help="Minimum lgmp value for mc lightcone")
+    "-m",
+    "--lgmp-min",
+    type=float,
+    default=10.5,
+    help="Minimum lgmp value for mc lightcone",
+)
 parser.add_argument(
-    "--num-halos", type=int, default=5000,
-    help="Number of halos for the mc lightcone")
+    "--num-halos", type=int, default=5000, help="Number of halos for the mc lightcone"
+)
 parser.add_argument(
-    "--param-results", type=str, default=None,
-    help="Results .npz file to load final parameter value from")
+    "--param-results",
+    type=str,
+    default=None,
+    help="Results .npz file to load final parameter value from",
+)
 parser.add_argument(
-    "--hmf-calibration", type=str, default=None,
-    help="Specify diffmahpop params ('smdpl_hmf', 'smdpl_shmf', 'hacc_shmf')")
+    "--hmf-calibration",
+    type=str,
+    default=None,
+    help="Specify diffmahpop params ('smdpl_hmf', 'smdpl_shmf', 'hacc_shmf')",
+)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -224,7 +268,8 @@ if __name__ == "__main__":
         num_halos=args.num_halos,
         i_thresh=args.iband_max,
         lgmp_min=args.lgmp_min,
-        hmf_calibration=args.hmf_calibration)
+        hmf_calibration=args.hmf_calibration,
+    )
 
     model_params = None
     if args.param_results:
@@ -234,9 +279,14 @@ if __name__ == "__main__":
         else:
             model_params = results["params"][-1]
 
-    n_of_z_plot(cosmos_fit, save=args.save, prefix=args.prefix,
-                model_params=model_params)
-    n_of_ithresh_plot(cosmos_fit, save=args.save, prefix=args.prefix,
-                      ithresh=args.iband_max, model_params=model_params)
-    smhm_drift_plot(save=args.save, prefix=args.prefix,
-                    model_params=model_params)
+    n_of_z_plot(
+        cosmos_fit, save=args.save, prefix=args.prefix, model_params=model_params
+    )
+    n_of_ithresh_plot(
+        cosmos_fit,
+        save=args.save,
+        prefix=args.prefix,
+        ithresh=args.iband_max,
+        model_params=model_params,
+    )
+    smhm_drift_plot(save=args.save, prefix=args.prefix, model_params=model_params)

--- a/diffskyopt/scripts/kdescent_fit_to_cosmos.py
+++ b/diffskyopt/scripts/kdescent_fit_to_cosmos.py
@@ -7,8 +7,15 @@ from mpi4py import MPI
 from ..lossfuncs.cosmos_fit import CosmosFit
 
 
-def adam_fit(cosmos_fit, out, seed=1, nsteps=1000, u_param_init=None,
-             learning_rate=0.1, progress=True):
+def adam_fit(
+    cosmos_fit,
+    out,
+    seed=1,
+    nsteps=1000,
+    u_param_init=None,
+    learning_rate=0.1,
+    progress=True,
+):
     # Run Adam optimization from random initializations and plot loss
     calc = cosmos_fit.get_multi_grad_calc()
     key = jax.random.key(seed)
@@ -16,61 +23,89 @@ def adam_fit(cosmos_fit, out, seed=1, nsteps=1000, u_param_init=None,
         u_param_init = cosmos_fit.default_u_param_arr
 
     params, losses = calc.run_adam(
-        u_param_init, nsteps=nsteps, learning_rate=learning_rate,
-        randkey=key, progress=progress)
+        u_param_init,
+        nsteps=nsteps,
+        learning_rate=learning_rate,
+        randkey=key,
+        progress=progress,
+    )
 
     if not MPI.COMM_WORLD.rank and out is not None:
-        np.savez(
-            out,
-            params=np.asarray(params),
-            losses=np.asarray(losses)
-        )
+        np.savez(out, params=np.asarray(params), losses=np.asarray(losses))
 
 
-parser = argparse.ArgumentParser(
-    description="Test real fits to COSMOS data")
+parser = argparse.ArgumentParser(description="Test real fits to COSMOS data")
 parser.add_argument(
-    "-o", "--output", type=str, default="cosmos_fit_results.npz",
-    help="Save plots instead of opening interactive window")
+    "-o",
+    "--output",
+    type=str,
+    default="cosmos_fit_results.npz",
+    help="Save plots instead of opening interactive window",
+)
 parser.add_argument(
-    "-i", "--input", type=str, default=None,
-    help="Previous results of which to start from the final params")
+    "-i",
+    "--input",
+    type=str,
+    default=None,
+    help="Previous results of which to start from the final params",
+)
 parser.add_argument(
-    "-n", "--nsteps", type=int, default=1000,
-    help="Number of adam fitting steps")
+    "-n", "--nsteps", type=int, default=1000, help="Number of adam fitting steps"
+)
 parser.add_argument(
-    "-l", "--learning-rate", type=float, default=0.1,
-    help="Learning rate for adam gradient descent")
+    "-l",
+    "--learning-rate",
+    type=float,
+    default=0.1,
+    help="Learning rate for adam gradient descent",
+)
+parser.add_argument("-s", "--seed", type=int, default=1, help="Random seed")
 parser.add_argument(
-    "-s", "--seed", type=int, default=1,
-    help="Random seed")
+    "--iband-max",
+    type=float,
+    default=25.0,
+    help="Only fit to data with apparent mag_i < IBAND_MAX",
+)
 parser.add_argument(
-    "--iband-max", type=float, default=25.0,
-    help="Only fit to data with apparent mag_i < IBAND_MAX")
+    "-m",
+    "--lgmp-min",
+    type=float,
+    default=10.5,
+    help="Minimum lgmp value for mc lightcone",
+)
 parser.add_argument(
-    "-m", "--lgmp-min", type=float, default=10.5,
-    help="Minimum lgmp value for mc lightcone")
+    "--num-halos", type=int, default=5000, help="Number of halos for the mc lightcone"
+)
 parser.add_argument(
-    "--num-halos", type=int, default=5000,
-    help="Number of halos for the mc lightcone")
+    "-k", "--num-kernels", type=int, default=40, help="Number of kernels for kdescent"
+)
 parser.add_argument(
-    "-k", "--num-kernels", type=int, default=40,
-    help="Number of kernels for kdescent")
+    "-f",
+    "--num-fourier-positions",
+    type=int,
+    default=20,
+    help="Number of Fourier evaluation positions for kdescent",
+)
 parser.add_argument(
-    "-f", "--num-fourier-positions", type=int, default=20,
-    help="Number of Fourier evaluation positions for kdescent")
+    "--num-mag-z-kernels",
+    type=int,
+    default=40,
+    help="Number of kernels for 2D mag-z kdescent term",
+)
 parser.add_argument(
-    "--num-mag-z-kernels", type=int, default=40,
-    help="Number of kernels for 2D mag-z kdescent term")
+    "--hmf-calibration",
+    type=str,
+    default=None,
+    help="Specify diffmahpop params ('smdpl_hmf', 'smdpl_shmf', 'hacc_shmf')",
+)
 parser.add_argument(
-    "--hmf-calibration", type=str, default=None,
-    help="Specify diffmahpop params ('smdpl_hmf', 'smdpl_shmf', 'hacc_shmf')")
+    "--log-loss",
+    action="store_true",
+    help="Perform logarithm on KDE counts for loss computation",
+)
 parser.add_argument(
-    "--log-loss", action="store_true",
-    help="Perform logarithm on KDE counts for loss computation")
-parser.add_argument(
-    "--kidw", type=float, default=0.0,
-    help="Inverse density weighting for kdescent")
+    "--kidw", type=float, default=0.0, help="Inverse density weighting for kdescent"
+)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -83,11 +118,17 @@ if __name__ == "__main__":
         hmf_calibration=args.hmf_calibration,
         log_loss=args.log_loss,
         num_mag_z_kernels=args.num_mag_z_kernels,
-        kde_idw_power=args.kidw)
+        kde_idw_power=args.kidw,
+    )
 
     u_param_init = None
     if args.input is not None:
         u_param_init = np.load(args.input)["params"][-1]
 
-    adam_fit(cosmos_fit, args.output, nsteps=args.nsteps,
-             learning_rate=args.learning_rate, u_param_init=u_param_init)
+    adam_fit(
+        cosmos_fit,
+        args.output,
+        nsteps=args.nsteps,
+        learning_rate=args.learning_rate,
+        u_param_init=u_param_init,
+    )

--- a/jobs/cosmos_fit/fit.pbs
+++ b/jobs/cosmos_fit/fit.pbs
@@ -8,7 +8,7 @@
 #PBS -A halotools
 # #PBS -A galsampler
 
-# queue name 
+# queue name
 # - Improv options: compute [default], bigmem
 # - Bebop only option: bdwall [default]
 # #PBS -q bigmem
@@ -22,8 +22,8 @@
 #PBS -l walltime=23:00:00
 
 # Load software
-source ~/.bashrc
-conda activate /lcrc/project/halotools/apearl/miniconda3/envs/main312
+source ~/.bash_profile
+conda activate diffskyopt312
 
 cd $PBS_O_WORKDIR
 # export DIFFSKYOPT_EXPAND_ZRANGE_SSP_ERR=1


### PR DESCRIPTION
There were some minor changes in Diffsky `v0.3` to accommodate Diffstar `v1.0`, which is a major update to the SFH model (see https://github.com/ArgonneCPAC/diffstar/pull/96 for details). This PR makes minor changes to restore compatibility with these updates.